### PR TITLE
Log invalid Facebook verify token in webhook handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1828,8 +1828,14 @@ app.get('/webhook/facebook/:botId', async (req, res) => {
     }
 
     // Handle Facebook webhook verification
-    if (req.query['hub.mode'] === 'subscribe' && req.query['hub.verify_token'] === facebookBot.verifyToken) {
-      return res.status(200).send(req.query['hub.challenge']);
+    if (req.query['hub.mode'] === 'subscribe') {
+      if (req.query['hub.verify_token'] === facebookBot.verifyToken) {
+        return res.status(200).send(req.query['hub.challenge']);
+      } else {
+        console.warn(
+          `[Facebook Bot: ${facebookBot.name}] Invalid verify token received: ${req.query['hub.verify_token']}`
+        );
+      }
     }
 
     return res.status(400).send('Invalid verification request');


### PR DESCRIPTION
## Summary
- log verify token mismatches for Facebook webhook with bot name and received token
- wrap log message for readability

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aeb68b003c833190b4fcfc10504ce3