### PR TITLE
feat: add public base url config

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -21,6 +21,9 @@ ADMIN_PASSWORD=admin123
 
 # Port Configuration
 PORT=3000
+
+# Public Base URL (โดเมนที่ Facebook เข้าถึงได้)
+PUBLIC_BASE_URL=https://your.domain.com
 ```
 
 ### 2. แก้ไขค่าตัวแปร
@@ -33,6 +36,7 @@ OPENAI_API_KEY=dummy_key
 MONGO_URI=mongodb://localhost:27017/chatbot
 ADMIN_PASSWORD=admin123
 PORT=3000
+PUBLIC_BASE_URL=http://localhost:3000
 ```
 
 **สำหรับการใช้งานจริง:**
@@ -42,6 +46,7 @@ PORT=3000
 - `MONGO_URI` - Connection string ของ MongoDB
 - `ADMIN_PASSWORD` - รหัสผ่านสำหรับเข้าระบบ Admin
 - `PORT` - Port ที่ต้องการให้แอปรัน (default: 3000)
+- `PUBLIC_BASE_URL` - โดเมน https ที่ Facebook เข้าถึงได้ (เช่น https://your.domain.com)
 
 ### 3. ติดตั้ง Dependencies
 ```bash

--- a/env.example
+++ b/env.example
@@ -13,3 +13,6 @@ MONGO_URI=mongodb+srv://username:password@cluster.mongodb.net/database
 
 # OpenAI API Key
 OPENAI_API_KEY=your_openai_api_key
+
+# Public base URL that Facebook can access
+PUBLIC_BASE_URL=https://your.domain.com

--- a/index.js
+++ b/index.js
@@ -2075,7 +2075,7 @@ app.post('/api/line-bots', async (req, res) => {
     // Generate unique webhook URL if not provided
     let finalWebhookUrl = webhookUrl;
     if (!finalWebhookUrl) {
-      const baseUrl = req.protocol + '://' + req.get('host');
+      const baseUrl = process.env.PUBLIC_BASE_URL || ('https://' + req.get('host'));
       const uniqueId = Date.now().toString(36) + Math.random().toString(36).substr(2);
       finalWebhookUrl = `${baseUrl}/webhook/line/${uniqueId}`;
     }
@@ -2278,7 +2278,7 @@ app.post('/api/facebook-bots/init', async (req, res) => {
     const id = insert.insertedId;
 
     // Build webhook URL using bot id
-    const baseUrl = req.protocol + '://' + req.get('host');
+    const baseUrl = process.env.PUBLIC_BASE_URL || ('https://' + req.get('host'));
     const webhookUrl = `${baseUrl}/webhook/facebook/${id.toString()}`;
 
     await coll.updateOne({ _id: id }, { $set: { webhookUrl } });
@@ -2345,7 +2345,7 @@ app.post('/api/facebook-bots', async (req, res) => {
     // Generate unique webhook URL if not provided
     let finalWebhookUrl = webhookUrl;
     if (!finalWebhookUrl) {
-      const baseUrl = req.protocol + '://' + req.get('host');
+      const baseUrl = process.env.PUBLIC_BASE_URL || ('https://' + req.get('host'));
       const uniqueId = Date.now().toString(36) + Math.random().toString(36).substr(2);
       finalWebhookUrl = `${baseUrl}/webhook/facebook/${uniqueId}`;
     }


### PR DESCRIPTION
## Summary
- allow LINE and Facebook webhook URLs to use a configurable `PUBLIC_BASE_URL`
- document `PUBLIC_BASE_URL` setup requirement for Facebook accessibility
- provide example env var in `env.example`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeb68959d88331bcc4efd64ac79935