### PR TITLE
Add missing Facebook Bot containers

### DIFF
--- a/views/admin-settings.ejs
+++ b/views/admin-settings.ejs
@@ -281,6 +281,17 @@
                                     <div class="col-md-6 mb-4">
                                         <div class="card border-0 shadow-sm">
                                             <div class="card-body text-center">
+                                                <i class="fab fa-facebook fa-3x text-primary mb-3"></i>
+                                                <h5>Facebook Bot ที่ใช้งาน</h5>
+                                                <div id="facebookBotOverview">
+                                                    <p class="text-muted">กำลังโหลดข้อมูล...</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6 mb-4">
+                                        <div class="card border-0 shadow-sm">
+                                            <div class="card-body text-center">
                                                 <i class="fas fa-book fa-3x text-info mb-3"></i>
                                                 <h5>Instructions ในคลัง</h5>
                                                 <div id="instructionsOverview">
@@ -670,6 +681,11 @@
                                 <!-- Line Bot List -->
                                 <div id="lineBotList">
                                     <!-- Line Bot items will be loaded here -->
+                                </div>
+
+                                <!-- Facebook Bot List -->
+                                <div id="facebookBotList">
+                                    <!-- Facebook Bot items will be loaded here -->
                                 </div>
 
                                 <!-- Global AI Settings -->


### PR DESCRIPTION
## Summary
- add Facebook Bot overview card in settings overview
- add container for Facebook Bot list

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aebb48de5483318aa4b6b067e279c7