### PR TITLE
Handle Facebook API errors more cleanly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1903,8 +1903,11 @@ async function sendFacebookMessage(recipientId, message, accessToken) {
     
     console.log('Facebook message sent successfully:', response.data);
   } catch (error) {
-    console.error('Error sending Facebook message:', error);
-    throw error;
+    const status = error.response?.status;
+    const fbMessage = error.response?.data?.error?.message || error.message;
+    const conciseError = status ? `Facebook API ${status}: ${fbMessage}` : fbMessage;
+    console.error('Error sending Facebook message:', conciseError);
+    throw new Error(conciseError);
   }
 }
 


### PR DESCRIPTION
## Summary
- Return concise Facebook API error messages with status codes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aec4c3cd2c8331979869ab79f49e79