### PR TITLE
feat: support facebook chat history and admin replies

### DIFF
--- a/utils/chatHistory.js
+++ b/utils/chatHistory.js
@@ -1,0 +1,25 @@
+const MAX_MESSAGES = 20;
+const histories = new Map();
+
+function getHistory(userId) {
+  return histories.get(userId) || [];
+}
+
+function addMessage(userId, role, content) {
+  const history = getHistory(userId);
+  history.push({ role, content });
+  if (history.length > MAX_MESSAGES) {
+    history.shift();
+  }
+  histories.set(userId, history);
+}
+
+function clearHistory(userId) {
+  histories.delete(userId);
+}
+
+module.exports = {
+  getHistory,
+  addMessage,
+  clearHistory
+};


### PR DESCRIPTION
## Summary
- add in-memory chat history storage
- persist facebook conversations and profile info
- enable admin chat replies for facebook users and improve error logs

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aec26fe6888331b21312fc68e19b2b