### PR TITLE
Ignore Facebook message echoes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1866,6 +1866,10 @@ app.post('/webhook/facebook/:botId', async (req, res) => {
     if (req.body.object === 'page') {
       for (let entry of req.body.entry) {
         for (let messagingEvent of entry.messaging) {
+          if (messagingEvent.message?.is_echo) {
+            continue;
+          }
+
           if (messagingEvent.message && messagingEvent.message.text) {
             const senderId = messagingEvent.sender.id;
             const message = messagingEvent.message.text;


### PR DESCRIPTION
## Summary
- Skip Facebook webhook `is_echo` messages so bot doesn't reply to itself

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aecf1b96308331901acccae7fac5a8