### PR TITLE
feat: improve admin settings UI and add instruction selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1386,6 +1386,7 @@ async function ensureSettings() {
     { key: "textModel", value: "gpt-5" },
     { key: "visionModel", value: "gpt-5" },
     { key: "maxImagesPerMessage", value: 3 },
+    { key: "defaultInstruction", value: "" },
     { key: "enableChatHistory", value: true },
     { key: "enableAdminNotifications", value: true },
     { key: "systemMode", value: "production" }
@@ -3149,6 +3150,7 @@ app.get('/api/settings', async (req, res) => {
       textModel: "gpt-5",
       visionModel: "gpt-5",
       maxImagesPerMessage: 3,
+      defaultInstruction: '',
       aiEnabled: true,
       enableChatHistory: true,
       enableAdminNotifications: true,
@@ -3217,7 +3219,7 @@ app.post('/api/settings/chat', async (req, res) => {
 // Save AI settings
 app.post('/api/settings/ai', async (req, res) => {
   try {
-    const { textModel, visionModel, maxImagesPerMessage } = req.body;
+    const { textModel, visionModel, maxImagesPerMessage, defaultInstruction } = req.body;
     
     const client = await connectDB();
     const db = client.db("chatbot");
@@ -3254,6 +3256,12 @@ app.post('/api/settings/ai', async (req, res) => {
     await coll.updateOne(
       { key: "maxImagesPerMessage" },
       { $set: { value: maxImagesPerMessage } },
+      { upsert: true }
+    );
+
+    await coll.updateOne(
+      { key: "defaultInstruction" },
+      { $set: { value: defaultInstruction || "" } },
       { upsert: true }
     );
     

--- a/views/admin-settings.ejs
+++ b/views/admin-settings.ejs
@@ -12,7 +12,7 @@
             border: 1px solid #e0e0e0;
             border-radius: 10px;
             box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            margin-bottom: 20px;
+            margin-bottom: 15px;
         }
         .settings-header {
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -21,7 +21,7 @@
             border-radius: 10px 10px 0 0;
         }
         .settings-body {
-            padding: 25px;
+            padding: 20px;
         }
         .form-control, .form-select {
             border-radius: 8px;
@@ -45,8 +45,8 @@
             box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
         }
         .setting-item {
-            margin-bottom: 25px;
-            padding: 20px;
+            margin-bottom: 15px;
+            padding: 15px;
             background: #f8f9fa;
             border-radius: 8px;
             border-left: 4px solid #667eea;
@@ -741,9 +741,19 @@
                                                     <div class="setting-description">
                                                         จำกัดจำนวนรูปภาพที่ AI จะประมวลผลในครั้งเดียวเพื่อควบคุมต้นทุน
                                                     </div>
-                                                    <input type="number" class="form-control" id="maxImagesPerMessage" 
+                                                <input type="number" class="form-control" id="maxImagesPerMessage"
                                                            min="1" max="10" step="1" placeholder="3" value="3">
                                                     <small class="text-muted">แนะนำ: 2-5 รูปภาพ</small>
+                                                </div>
+
+                                                <div class="setting-item">
+                                                    <div class="setting-label">Instruction เริ่มต้น</div>
+                                                    <div class="setting-description">
+                                                        เลือกคลัง instruction ที่จะใช้เป็นค่าเริ่มต้นเมื่อบอทไม่ได้เลือกไว้
+                                                    </div>
+                                                    <select class="form-select" id="defaultInstruction">
+                                                        <option value="">ไม่เลือก</option>
+                                                    </select>
                                                 </div>
 
                                                 <button type="submit" class="btn btn-save text-white">
@@ -1209,21 +1219,45 @@
                 if (response.ok) {
                     currentSettings = await response.json();
                     populateSettings();
+                    await loadInstructionOptions();
                 } else {
                     showAlert('ไม่สามารถโหลดการตั้งค่าได้', 'danger');
                 }
-                
+
                 // โหลดข้อมูล AI Model ของ Line Bot
                 await loadLineBotAiModelInfo();
-                
+
                 // โหลดข้อมูล Facebook Bot
                 await loadFacebookBotSettings();
-                
+
                 // โหลดข้อมูลภาพรวมระบบ
                 await loadOverviewData();
             } catch (error) {
                 console.error('Error loading settings:', error);
                 showAlert('เกิดข้อผิดพลาดในการโหลดการตั้งค่า', 'danger');
+            }
+        }
+
+        async function loadInstructionOptions() {
+            try {
+                const response = await fetch('/api/instructions/library');
+                const select = document.getElementById('defaultInstruction');
+                if (!select) return;
+                if (response.ok) {
+                    const result = await response.json();
+                    select.innerHTML = '<option value="">ไม่เลือก</option>';
+                    (result.libraries || []).forEach(lib => {
+                        const opt = document.createElement('option');
+                        opt.value = lib.date;
+                        opt.textContent = lib.name || lib.displayDate;
+                        select.appendChild(opt);
+                    });
+                    if (currentSettings.defaultInstruction) {
+                        select.value = currentSettings.defaultInstruction;
+                    }
+                }
+            } catch (error) {
+                console.error('Error loading instruction libraries:', error);
             }
         }
 
@@ -1266,6 +1300,12 @@
                 document.getElementById('maxImagesPerMessage').value = currentSettings.maxImagesPerMessage;
             } else {
                 document.getElementById('maxImagesPerMessage').value = 3; // ค่าเริ่มต้น
+            }
+
+            if (currentSettings.defaultInstruction !== undefined) {
+                document.getElementById('defaultInstruction').value = currentSettings.defaultInstruction;
+            } else {
+                document.getElementById('defaultInstruction').value = '';
             }
 
             // System settings
@@ -1395,7 +1435,8 @@
             const settings = {
                 textModel: document.getElementById('textModel').value,
                 visionModel: document.getElementById('visionModel').value,
-                maxImagesPerMessage: parseInt(document.getElementById('maxImagesPerMessage').value)
+                maxImagesPerMessage: parseInt(document.getElementById('maxImagesPerMessage').value),
+                defaultInstruction: document.getElementById('defaultInstruction').value
             };
 
             try {
@@ -1579,7 +1620,7 @@
                                     <div class="d-flex align-items-center gap-2">
                                         <span class="badge bg-${statusClass}">${statusText}</span>
                                         <button class="btn btn-sm btn-outline-info" title="จัดการ Instructions" onclick="manageInstructions('${bot._id}')">
-                                            <i class="fas fa-book"></i>
+                                            <i class="fas fa-book me-1"></i>Instructions
                                         </button>
                                         <button class="btn btn-sm btn-outline-secondary" title="แก้ไข" onclick="editLineBot('${bot._id}')">
                                             <i class="fas fa-edit"></i>


### PR DESCRIPTION
## Summary
- streamline admin settings layout for a more compact dashboard feel
- expose a global instruction selector and make instruction management buttons more visible
- persist selected default instructions via settings API

## Testing
- `node --check index.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeda271228833188d111c835717930