### PR TITLE
Revamp Bot & AI settings layout for Facebook bots

### DIFF
--- a/views/admin-settings.ejs
+++ b/views/admin-settings.ejs
@@ -684,7 +684,7 @@
                                 </div>
 
                                 <!-- Facebook Bot List -->
-                                <div id="facebookBotList">
+                                <div id="facebookBotList" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
                                     <!-- Facebook Bot items will be loaded here -->
                                 </div>
 
@@ -1111,7 +1111,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="manageInstructionsModalLabel">
-                        <i class="fas fa-book me-2"></i>จัดการ Instructions สำหรับ Line Bot
+                        <i class="fas fa-book me-2"></i>จัดการ Instructions สำหรับ Bot
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
@@ -1135,7 +1135,7 @@
                         <h6><i class="fas fa-info-circle me-2"></i>คำแนะนำ</h6>
                         <ul class="text-muted small">
                             <li>คลิกที่คลัง instruction เพื่อดูรายละเอียด</li>
-                            <li>เลือก instruction ที่ต้องการใช้ใน Line Bot นี้</li>
+                            <li>เลือก instruction ที่ต้องการใช้ในบอทนี้</li>
                             <li>สามารถเปลี่ยนการเลือกใช้ได้ตลอดเวลา</li>
                             <li>การเปลี่ยนแปลงจะมีผลทันทีหลังจากบันทึก</li>
                         </ul>
@@ -1619,7 +1619,7 @@
                                     </div>
                                     <div class="d-flex align-items-center gap-2">
                                         <span class="badge bg-${statusClass}">${statusText}</span>
-                                        <button class="btn btn-sm btn-outline-info" title="จัดการ Instructions" onclick="manageInstructions('${bot._id}')">
+                                        <button class="btn btn-sm btn-outline-info" title="จัดการ Instructions" onclick="manageInstructions('${bot._id}', 'line')">
                                             <i class="fas fa-book me-1"></i>Instructions
                                         </button>
                                         <button class="btn btn-sm btn-outline-secondary" title="แก้ไข" onclick="editLineBot('${bot._id}')">
@@ -2066,12 +2066,16 @@
                 console.log('Facebook Bot List container not found');
                 return;
             }
-            
+
             if (!facebookBots || facebookBots.length === 0) {
                 container.innerHTML = `
-                    <div class="alert alert-info">
-                        <i class="fas fa-info-circle me-2"></i>
-                        ยังไม่มี Facebook Bot ในระบบ
+                    <div class="text-center py-5">
+                        <i class="fab fa-facebook fa-4x text-muted mb-3"></i>
+                        <h5 class="text-muted">ยังไม่มี Facebook Bot ในระบบ</h5>
+                        <p class="text-muted">เริ่มต้นด้วยการเพิ่ม Facebook Bot ใหม่</p>
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addFacebookBotModal">
+                            <i class="fas fa-plus me-2"></i>เพิ่ม Facebook Bot ใหม่
+                        </button>
                     </div>
                 `;
                 return;
@@ -2079,71 +2083,61 @@
 
             let html = '';
             facebookBots.forEach(bot => {
-                const statusClass = bot.status === 'active' ? 'success' : 
-                                  bot.status === 'inactive' ? 'warning' : 'secondary';
-                const statusText = bot.status === 'active' ? 'ใช้งาน' : 
-                                 bot.status === 'inactive' ? 'ปิดใช้งาน' : 'บำรุงรักษา';
-                const defaultBadge = bot.isDefault ? ' <span class="badge bg-primary">Default</span>' : '';
+                const statusClass = bot.status === 'active' ? 'success' :
+                                    bot.status === 'inactive' ? 'warning' : 'secondary';
+                const statusText = bot.status === 'active' ? 'ใช้งาน' :
+                                   bot.status === 'inactive' ? 'ปิดใช้งาน' : 'บำรุงรักษา';
+                const defaultBadge = bot.isDefault ? '<span class="badge bg-primary ms-2">Default</span>' : '';
+                const instructionsCount = bot.selectedInstructions ? bot.selectedInstructions.length : 0;
 
                 html += `
-                    <div class="card mb-3 shadow-sm">
-                        <div class="card-body">
-                            <div class="row align-items-center">
-                                <div class="col-md-6">
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <h6 class="mb-0">
-                                                <i class="fab fa-facebook me-2 text-primary"></i>
-                                                ${bot.name} ${defaultBadge}
-                                            </h6>
-                                            <small class="text-muted">${bot.description || 'ไม่มีคำอธิบาย'}</small>
-                                        </div>
-                                        <div class="d-flex align-items-center gap-2">
-                                            <span class="badge bg-${statusClass}">${statusText}</span>
-                                            <div class="dropdown">
-                                                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                                                    <i class="fas fa-ellipsis-v"></i>
-                                                </button>
-                                                <ul class="dropdown-menu">
-                                                    <li><a class="dropdown-item" href="#" onclick="editFacebookBot('${bot._id}')">
-                                                        <i class="fas fa-edit me-2"></i>แก้ไข
-                                                    </a></li>
-                                                    <li><a class="dropdown-item" href="#" onclick="manageFacebookInstructions('${bot._id}')">
-                                                        <i class="fas fa-book me-2"></i>จัดการ Instructions
-                                                    </a></li>
-                                                    <li><a class="dropdown-item" href="#" onclick="testFacebookBot('${bot._id}')">
-                                                        <i class="fas fa-play me-2"></i>ทดสอบ
-                                                    </a></li>
-                                                    <li><hr class="dropdown-divider"></li>
-                                                    <li><a class="dropdown-item text-danger" href="#" onclick="deleteFacebookBot('${bot._id}')">
-                                                        <i class="fas fa-trash me-2"></i>ลบ
-                                                    </a></li>
-                                                </ul>
-                                            </div>
-                                        </div>
+                    <div class="col">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-header bg-white border-bottom">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <h6 class="mb-0">
+                                            <i class="fab fa-facebook me-2 text-primary"></i>${bot.name} ${defaultBadge}
+                                        </h6>
+                                        <small class="text-muted">${bot.description || 'ไม่มีคำอธิบาย'}</small>
+                                    </div>
+                                    <div class="d-flex align-items-center gap-2">
+                                        <span class="badge bg-${statusClass}">${statusText}</span>
+                                        <button class="btn btn-sm btn-outline-info" title="จัดการ Instructions" onclick="manageInstructions('${bot._id}', 'facebook')">
+                                            <i class="fas fa-book me-1"></i>Instructions
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-secondary" title="แก้ไข" onclick="editFacebookBot('${bot._id}')">
+                                            <i class="fas fa-edit"></i>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-primary" title="ทดสอบ" onclick="testFacebookBot('${bot._id}')">
+                                            <i class="fas fa-vial"></i>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-danger" title="ลบ" onclick="deleteFacebookBot('${bot._id}')">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
                                     </div>
                                 </div>
-                                <div class="col-md-6">
-                                    <div class="row">
-                                        <div class="col-md-4">
-                                            <div class="d-flex align-items-center mb-2">
-                                                <small class="text-muted d-block">AI Model</small>
-                                                <span class="badge bg-info">${bot.aiModel || 'gpt-5'}</span>
-                                            </div>
+                            </div>
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-6 col-md-4">
+                                        <div class="d-flex align-items-center mb-2">
+                                            <small class="text-muted d-block me-2">AI Model</small>
+                                            <span class="badge bg-info">${bot.aiModel || 'gpt-5'}</span>
                                         </div>
-                                        <div class="col-md-4">
-                                            <div class="d-flex align-items-center mb-2">
-                                                <small class="text-muted d-block">Page ID</small>
-                                                <small class="text-truncate d-block" style="max-width: 150px;" title="${bot.pageId || 'ไม่ระบุ'}">
-                                                    ${bot.pageId ? bot.pageId.substring(0, 10) + '...' : 'ไม่ระบุ'}
-                                                </small>
-                                            </div>
+                                    </div>
+                                    <div class="col-6 col-md-4">
+                                        <div class="d-flex align-items-center mb-2">
+                                            <small class="text-muted d-block me-2">Page ID</small>
+                                            <small class="text-truncate d-block" style="max-width: 150px;" title="${bot.pageId || 'ไม่ระบุ'}">
+                                                ${bot.pageId ? bot.pageId.substring(0, 10) + '...' : 'ไม่ระบุ'}
+                                            </small>
                                         </div>
-                                        <div class="col-md-4">
-                                            <div class="d-flex align-items-center mb-2">
-                                                <small class="text-muted d-block">Instructions</small>
-                                                <span class="badge bg-secondary">${bot.selectedInstructions ? bot.selectedInstructions.length : 0}</span>
-                                            </div>
+                                    </div>
+                                    <div class="col-6 col-md-4">
+                                        <div class="d-flex align-items-center mb-2">
+                                            <small class="text-muted d-block me-2">Instructions</small>
+                                            <span class="badge bg-secondary">${instructionsCount}</span>
                                         </div>
                                     </div>
                                 </div>
@@ -2152,7 +2146,6 @@
                     </div>
                 `;
             });
-            
             container.innerHTML = html;
         }
 
@@ -2382,38 +2375,47 @@
         }
 
         // Global variables for instruction management
-        let currentLineBotId = null;
-        let currentLineBotInstructions = [];
+        let currentBotId = null;
+        let currentBotInstructions = [];
+        let currentBotType = '';
         let availableLibraries = [];
 
-        // Manage Instructions for Line Bot
-        async function manageInstructions(botId) {
-            currentLineBotId = botId;
-            currentLineBotInstructions = [];
-            
+        // Manage Instructions for Line or Facebook Bot
+        async function manageInstructions(botId, botType = 'line') {
+            currentBotId = botId;
+            currentBotType = botType;
+            currentBotInstructions = [];
+
             try {
-                // Load Line Bot details
-                const botResponse = await fetch(`/api/line-bots/${botId}`);
+                // Load Bot details
+                const botResponse = await fetch(`/api/${botType}-bots/${botId}`);
                 if (botResponse.ok) {
                     const bot = await botResponse.json();
-                    currentLineBotInstructions = bot.selectedInstructions || [];
+                    currentBotInstructions = bot.selectedInstructions || [];
                 }
-                
+
                 // Load available instruction libraries
                 const libraryResponse = await fetch('/api/instructions/library');
                 if (libraryResponse.ok) {
                     const result = await libraryResponse.json();
                     availableLibraries = result.libraries || [];
                 }
-                
+
                 // Display data
                 displayInstructionLibraries();
                 displaySelectedInstructions();
-                
+
+                // Update modal title
+                const titleEl = document.getElementById('manageInstructionsModalLabel');
+                if (titleEl) {
+                    const platformName = botType === 'line' ? 'Line' : 'Facebook';
+                    titleEl.innerHTML = `<i class="fas fa-book me-2"></i>จัดการ Instructions สำหรับ ${platformName} Bot`;
+                }
+
                 // Show modal
                 const modal = new bootstrap.Modal(document.getElementById('manageInstructionsModal'));
                 modal.show();
-                
+
             } catch (error) {
                 console.error('Error loading instruction data:', error);
                 showAlert('เกิดข้อผิดพลาดในการโหลดข้อมูล instructions', 'danger');
@@ -2436,7 +2438,7 @@
 
             let html = '';
             availableLibraries.forEach(library => {
-                const isSelected = currentLineBotInstructions.includes(library.date);
+                const isSelected = currentBotInstructions.includes(library.date);
                 const selectedClass = isSelected ? 'border-success bg-light' : 'border-secondary';
                 const selectedIcon = isSelected ? '<i class="fas fa-check-circle text-success me-2"></i>' : '<i class="fas fa-circle text-muted me-2"></i>';
                 
@@ -2478,8 +2480,8 @@
         // Display selected instructions
         function displaySelectedInstructions() {
             const container = document.getElementById('selectedInstructions');
-            
-            if (currentLineBotInstructions.length === 0) {
+
+            if (currentBotInstructions.length === 0) {
                 container.innerHTML = `
                     <div class="alert alert-warning">
                         <i class="fas fa-exclamation-triangle me-2"></i>
@@ -2490,7 +2492,7 @@
             }
 
             let html = '<div class="mb-2"><strong>คลังที่เลือกใช้:</strong></div>';
-            currentLineBotInstructions.forEach(date => {
+            currentBotInstructions.forEach(date => {
                 const library = availableLibraries.find(lib => lib.date === date);
                 if (library) {
                     html += `
@@ -2518,13 +2520,13 @@
 
         // Toggle library selection
         function toggleLibrarySelection(date) {
-            const index = currentLineBotInstructions.indexOf(date);
+            const index = currentBotInstructions.indexOf(date);
             if (index > -1) {
                 // Remove if already selected
-                currentLineBotInstructions.splice(index, 1);
+                currentBotInstructions.splice(index, 1);
             } else {
                 // Add if not selected
-                currentLineBotInstructions.push(date);
+                currentBotInstructions.push(date);
             }
             
             // Refresh display
@@ -2534,9 +2536,9 @@
 
         // Remove library selection
         function removeLibrarySelection(date) {
-            const index = currentLineBotInstructions.indexOf(date);
+            const index = currentBotInstructions.indexOf(date);
             if (index > -1) {
-                currentLineBotInstructions.splice(index, 1);
+                currentBotInstructions.splice(index, 1);
                 displayInstructionLibraries();
                 displaySelectedInstructions();
             }
@@ -2544,28 +2546,35 @@
 
         // Save selected instructions
         async function saveSelectedInstructions() {
-            if (!currentLineBotId) {
-                showAlert('ไม่พบ Line Bot ID', 'danger');
+            if (!currentBotId) {
+                showAlert('ไม่พบ Bot ID', 'danger');
                 return;
             }
 
             try {
-                const response = await fetch(`/api/line-bots/${currentLineBotId}/instructions`, {
+                const url = currentBotType === 'line'
+                    ? `/api/line-bots/${currentBotId}/instructions`
+                    : `/api/facebook-bots/${currentBotId}/instructions`;
+                const response = await fetch(url, {
                     method: 'PUT',
                     headers: {
                         'Content-Type': 'application/json'
                     },
                     body: JSON.stringify({
-                        selectedInstructions: currentLineBotInstructions
+                        selectedInstructions: currentBotInstructions
                     })
                 });
 
                 if (response.ok) {
                     showAlert('บันทึกการเลือกใช้ instructions เรียบร้อยแล้ว', 'success');
-                    
-                    // Refresh Line Bot list
-                    await loadLineBotSettings();
-                    
+
+                    // Refresh bot list
+                    if (currentBotType === 'line') {
+                        await loadLineBotSettings();
+                    } else {
+                        await loadFacebookBotSettings();
+                    }
+
                     // Close modal
                     const modal = bootstrap.Modal.getInstance(document.getElementById('manageInstructionsModal'));
                     modal.hide();


### PR DESCRIPTION
## Summary
- Align Facebook bot section layout with Line bot cards
- Replace dropdown menu with visible action buttons to fix hidden edit option
- Share instruction management modal across Line and Facebook bots to avoid missing handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aedc1347208331848cafabc5e90931