### PR TITLE
Handle table instructions and avoid bot name lookup

### DIFF
--- a/AI_MODEL_PER_LINE_BOT_README.md
+++ b/AI_MODEL_PER_LINE_BOT_README.md
@@ -53,13 +53,17 @@ const aiModel = lineBot.aiModel || 'gpt-5';
 // ดึง system prompt จาก instructions ที่เลือก
 let systemPrompt = 'คุณเป็น AI Assistant ที่ช่วยตอบคำถามผู้ใช้';
 if (lineBot.selectedInstructions && lineBot.selectedInstructions.length > 0) {
-  // ดึง instructions จากคลัง
-  const instructions = await instructionColl.find({
+  // ดึง instructions จากคลังและแปลงเป็นข้อความ
+  const libraries = await instructionColl.find({
     _id: { $in: lineBot.selectedInstructions.map(id => new ObjectId(id)) }
   }).toArray();
-  
-  if (instructions.length > 0) {
-    systemPrompt = instructions.map(inst => inst.instructions).join('\n\n');
+
+  const allInstr = libraries.flatMap(lib => lib.instructions || []);
+  const instrTexts = allInstr
+    .map(i => i.type === 'table' ? tableInstructionToMarkdown(i) : i.content)
+    .filter(Boolean);
+  if (instrTexts.length > 0) {
+    systemPrompt = instrTexts.join('\n\n');
   }
 }
 


### PR DESCRIPTION
## Summary
- Flatten instruction libraries and convert table instructions to Markdown for system prompts
- Avoid duplicate bot lookup by passing bot objects directly to AI processing functions
- Document updated system prompt handling for line bots

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aee6a581788331b71bb7833271b79b