### PR TITLE
Convert table instructions to JSON in system prompts

### DIFF
--- a/AI_MODEL_PER_LINE_BOT_README.md
+++ b/AI_MODEL_PER_LINE_BOT_README.md
@@ -60,7 +60,7 @@ if (lineBot.selectedInstructions && lineBot.selectedInstructions.length > 0) {
 
   const allInstr = libraries.flatMap(lib => lib.instructions || []);
   const instrTexts = allInstr
-    .map(i => i.type === 'table' ? tableInstructionToMarkdown(i) : i.content)
+    .map(i => i.type === 'table' ? tableInstructionToJSON(i) : i.content)
     .filter(Boolean);
   if (instrTexts.length > 0) {
     systemPrompt = instrTexts.join('\n\n');

--- a/index.js
+++ b/index.js
@@ -1926,17 +1926,15 @@ async function sendFacebookMessage(recipientId, message, accessToken) {
   }
 }
 
-// Convert table instruction data to a readable Markdown string
-function tableInstructionToMarkdown(instruction) {
-  const columns = instruction?.data?.columns || [];
+// Convert table instruction data to a JSON string
+function tableInstructionToJSON(instruction) {
   const rows = instruction?.data?.rows || [];
-  if (columns.length === 0 || rows.length === 0) return instruction.content || '';
+  if (rows.length === 0) return instruction.content || '';
 
-  const headerRow = `| ${columns.join(' | ')} |`;
-  const separatorRow = `| ${columns.map(() => '---').join(' | ')} |`;
-  const bodyRows = rows.map(row => `| ${columns.map(col => row[col] || '').join(' | ')} |`).join('\n');
   const titleLine = instruction.title ? `${instruction.title}\n` : '';
-  return `${titleLine}${headerRow}\n${separatorRow}\n${bodyRows}`;
+  const contentLine = instruction.content ? `${instruction.content}\n` : '';
+  const jsonRows = JSON.stringify(rows, null, 2);
+  return `${titleLine}${contentLine}${jsonRows}`;
 }
 
 // Build system prompt text from selected instruction libraries
@@ -1944,7 +1942,7 @@ function buildSystemPromptFromLibraries(libraries) {
   const allInstructions = libraries.flatMap(lib => lib.instructions || []);
   const parts = allInstructions.map(inst => {
     if (inst.type === 'table') {
-      return tableInstructionToMarkdown(inst);
+      return tableInstructionToJSON(inst);
     }
     return inst.content || '';
   }).filter(text => text && text.trim() !== '');


### PR DESCRIPTION
## Summary
- Render table-based instructions as JSON strings and include them in system prompts
- Update documentation to reference `tableInstructionToJSON`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aee6a581788331b71bb7833271b79b