### PR TITLE
feat: support renaming and deleting instruction libraries

### DIFF
--- a/INSTRUCTION_LIBRARY_README.md
+++ b/INSTRUCTION_LIBRARY_README.md
@@ -30,10 +30,16 @@
 - สามารถเปลี่ยนการเลือกใช้ได้ตลอดเวลา
 - รองรับการเลือกหลายคลังพร้อมกัน
 
+### การจัดการ Instruction Library
+- สามารถเปลี่ยนชื่อและคำอธิบายของคลังได้
+- สามารถลบคลังที่ไม่ต้องการออกจากระบบได้
+
 ### API ใหม่
 - `PUT /api/line-bots/:id/instructions` - อัปเดต instructions ที่เลือกใช้
 - `GET /api/instructions/library` - ดึงรายการคลัง instructions
 - `GET /api/instructions/library/:date/details` - ดึงรายละเอียดคลังพร้อม instructions
+- `PUT /admin/instructions/library/:date` - เปลี่ยนชื่อหรือคำอธิบายของคลัง
+- `DELETE /admin/instructions/library/:date` - ลบคลัง instruction
 
 ## การใช้งาน
 
@@ -48,6 +54,19 @@ POST /admin/instructions/library-now
 
 // สร้างอัตโนมัติ (ทุกวันเวลา 00:00 น.)
 // ระบบจะสร้างคลังอัตโนมัติทุกวัน
+```
+
+### 1.1 แก้ไข/ลบ Instruction Library
+```javascript
+// เปลี่ยนชื่อหรือคำอธิบายของคลัง
+PUT /admin/instructions/library/:date
+{
+  "name": "ชื่อใหม่",
+  "description": "คำอธิบายใหม่"
+}
+
+// ลบคลังที่ไม่ต้องการ
+DELETE /admin/instructions/library/:date
 ```
 
 ### 2. จัดการ Instructions ใน Line Bot

--- a/index.js
+++ b/index.js
@@ -1578,6 +1578,53 @@ app.post('/admin/instructions/library-now', async (req, res) => {
   }
 });
 
+// Route: อัปเดตชื่อหรือคำอธิบายของ instruction library
+app.put('/admin/instructions/library/:date', async (req, res) => {
+  try {
+    const { date } = req.params;
+    const { name, description } = req.body;
+
+    const client = await connectDB();
+    const db = client.db("chatbot");
+    const libraryColl = db.collection("instruction_library");
+
+    const updateFields = {};
+    if (name !== undefined) updateFields.name = name;
+    if (description !== undefined) updateFields.description = description;
+
+    if (Object.keys(updateFields).length === 0) {
+      return res.json({ success: false, error: 'ไม่มีข้อมูลที่ต้องการอัปเดต' });
+    }
+
+    const result = await libraryColl.updateOne({ date }, { $set: updateFields });
+    if (result.matchedCount === 0) {
+      return res.json({ success: false, error: 'ไม่พบคลัง instruction ของวันที่ระบุ' });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    res.json({ success: false, error: err.message });
+  }
+});
+
+// Route: ลบ instruction library ตามวันที่ระบุ
+app.delete('/admin/instructions/library/:date', async (req, res) => {
+  try {
+    const { date } = req.params;
+
+    const client = await connectDB();
+    const db = client.db("chatbot");
+    const libraryColl = db.collection("instruction_library");
+
+    const result = await libraryColl.deleteOne({ date });
+    if (result.deletedCount === 0) {
+      return res.json({ success: false, error: 'ไม่พบคลัง instruction ของวันที่ระบุ' });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    res.json({ success: false, error: err.message });
+  }
+});
+
 // Route: คืนค่า instruction library
 app.post('/admin/instructions/restore/:date', async (req, res) => {
   try {

--- a/views/admin-dashboard.ejs
+++ b/views/admin-dashboard.ejs
@@ -1096,16 +1096,16 @@
             }
 
             let html = '<div class="list-group">';
-            
+
             libraries.forEach(library => {
                 const libraryDate = new Date(library.savedAt);
                 const isManual = library.type === 'manual';
                 const isBeforeRestore = library.type === 'before_restore';
-                
+
                 let typeIcon = 'fas fa-clock';
                 let typeText = 'อัตโนมัติ';
                 let typeClass = 'text-info';
-                
+
                 if (isManual) {
                     typeIcon = 'fas fa-user';
                     typeText = 'ด้วยตนเอง';
@@ -1135,9 +1135,21 @@
                                     บันทึกเมื่อ: ${libraryDate.toLocaleString('th-TH')}
                                 </small>
                             </div>
-                            <div>
-                                <button class="btn btn-outline-warning btn-sm restore-library" 
-                                        data-date="${library.date}" 
+                            <div class="text-end">
+                                <button class="btn btn-outline-secondary btn-sm edit-library"
+                                        data-date="${library.date}"
+                                        data-name="${library.name || ''}"
+                                        data-description="${library.description || ''}"
+                                        title="แก้ไขชื่อ/คำอธิบาย">
+                                    <i class="fas fa-edit me-1"></i> แก้ไข
+                                </button>
+                                <button class="btn btn-outline-danger btn-sm delete-library"
+                                        data-date="${library.date}"
+                                        title="ลบ library นี้">
+                                    <i class="fas fa-trash me-1"></i> ลบ
+                                </button>
+                                <button class="btn btn-outline-warning btn-sm restore-library"
+                                        data-date="${library.date}"
                                         data-display="${library.name || library.displayDate || library.date}"
                                         title="คืนค่า library นี้">
                                     <i class="fas fa-undo me-1"></i> คืนค่า
@@ -1147,28 +1159,85 @@
                     </div>
                 `;
             });
-            
+
             html += '</div>';
             libraryListContainer.innerHTML = html;
 
-            // Setup event listeners for restore buttons
-            setupRestoreEventListeners();
+            // Setup event listeners for library actions
+            setupLibraryEventListeners();
         }
 
-        // ฟังก์ชันจัดการปุ่มคืนค่า
-        function setupRestoreEventListeners() {
+        // ฟังก์ชันจัดการปุ่ม library (คืนค่า/แก้ไข/ลบ)
+        function setupLibraryEventListeners() {
+            // Restore
             document.querySelectorAll('.restore-library').forEach(btn => {
                 btn.addEventListener('click', function() {
                     currentRestoreLibraryDate = this.getAttribute('data-date');
                     const displayDate = this.getAttribute('data-display');
-                    
+
                     // อัพเดตข้อความใน confirmation modal
                     const modalBody = document.querySelector('#restoreConfirmModal .modal-body');
                     modalBody.querySelector('p').innerHTML = `<strong>คุณกำลังจะคืนค่า instructions จาก library: ${displayDate}</strong>`;
-                    
+
                     // เปิด confirmation modal
                     const restoreModal = new bootstrap.Modal(document.getElementById('restoreConfirmModal'));
                     restoreModal.show();
+                });
+            });
+
+            // Edit name/description
+            document.querySelectorAll('.edit-library').forEach(btn => {
+                btn.addEventListener('click', async function() {
+                    const date = this.getAttribute('data-date');
+                    const currentName = this.getAttribute('data-name') || '';
+                    const currentDesc = this.getAttribute('data-description') || '';
+
+                    const newName = prompt('ชื่อคลังใหม่:', currentName);
+                    if (newName === null) return;
+                    const newDesc = prompt('คำอธิบายใหม่:', currentDesc);
+                    if (newDesc === null) return;
+
+                    try {
+                        const response = await fetch(`/admin/instructions/library/${date}`, {
+                            method: 'PUT',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ name: newName, description: newDesc })
+                        });
+                        const data = await response.json();
+                        if (data.success) {
+                            showNotification('อัพเดตข้อมูลคลังเรียบร้อยแล้ว', 'success');
+                            await loadLibraryList();
+                        } else {
+                            showNotification('ไม่สามารถอัพเดตคลังได้: ' + data.error, 'error');
+                        }
+                    } catch (error) {
+                        console.error('Error updating library:', error);
+                        showNotification('เกิดข้อผิดพลาดในการอัพเดตคลัง', 'error');
+                    }
+                });
+            });
+
+            // Delete library
+            document.querySelectorAll('.delete-library').forEach(btn => {
+                btn.addEventListener('click', async function() {
+                    const date = this.getAttribute('data-date');
+                    if (!confirm('ต้องการลบคลังนี้หรือไม่?')) return;
+
+                    try {
+                        const response = await fetch(`/admin/instructions/library/${date}`, {
+                            method: 'DELETE'
+                        });
+                        const data = await response.json();
+                        if (data.success) {
+                            showNotification('ลบคลังเรียบร้อยแล้ว', 'success');
+                            await loadLibraryList();
+                        } else {
+                            showNotification('ไม่สามารถลบคลังได้: ' + data.error, 'error');
+                        }
+                    } catch (error) {
+                        console.error('Error deleting library:', error);
+                        showNotification('เกิดข้อผิดพลาดในการลบคลัง', 'error');
+                    }
                 });
             });
         }


### PR DESCRIPTION
## Summary
- allow updating name/description of instruction libraries via new PUT endpoint
- allow removing instruction libraries via new DELETE endpoint
- add dashboard controls to edit or delete libraries and update docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aefb1de2c88331b0d44a99c37e7512